### PR TITLE
Chart updates to better support SecurityContexts

### DIFF
--- a/chart/kproximate/Chart.lock
+++ b/chart/kproximate/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.0.3
-digest: sha256:1d23d03ea9a462a97dde9c47925ffd13cc9183bf611722c6ec1d98a46f4580a7
-generated: "2024-05-03T08:42:44.5818284+01:00"
+  version: 16.0.2
+digest: sha256:b3e206f5c405e4218b756df9ed867d157304c2d84ed58702434410742bf66bf9
+generated: "2025-05-07T12:35:07.68129838-07:00"

--- a/chart/kproximate/Chart.yaml
+++ b/chart/kproximate/Chart.yaml
@@ -1,30 +1,10 @@
 apiVersion: v2
-name: kproximate
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: 0.2.0
-
 dependencies:
-  - name: rabbitmq
-    version: 12.0.3
-    repository: oci://registry-1.docker.io/bitnamicharts
-
+- name: rabbitmq
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.0.2
+description: A Helm chart for Kubernetes
+name: kproximate
+type: application
+version: 0.2.3

--- a/chart/kproximate/templates/controller-deployment.yaml
+++ b/chart/kproximate/templates/controller-deployment.yaml
@@ -76,3 +76,5 @@ spec:
           while [ $(curl -sw '%{http_code}' --user ${rabbitMQUser}:${rabbitMQPassword} "http://${rabbitMQHost}:15672/api/health/checks/local-alarms" -o /dev/null) -ne 200 ]; do
             sleep 5;
           done
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/kproximate/templates/worker-deployment.yaml
+++ b/chart/kproximate/templates/worker-deployment.yaml
@@ -87,3 +87,5 @@ spec:
           while [ $(curl -sw '%{http_code}' --user ${rabbitMQUser}:${rabbitMQPassword} "http://${rabbitMQHost}:15672/api/health/checks/local-alarms" -o /dev/null) -ne 200 ]; do
             sleep 5;
           done
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
Ran into a few issues when deploying the chart on a CIS hardened RKE2 cluster related to the security contexts not being applied to the init containers. I modified the templates to apply them and bumped the RabbitMQ chart version to the latest that includes the same security directives. Ran a few tests and everything seems to be working correctly.